### PR TITLE
Add link summarization tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,27 @@ script.
    ```
 
    The assistant will call the tool and display the results in the
-   conversation.
+  conversation.
+
+## Summarizing links
+
+The `summarize_url` function lets the assistant fetch a web page and produce a concise summary.
+You can control the style with the `mode` parameter:
+
+- `reference` – Include a citation to the author, e.g. `In [title](url) @Author wrote ...`.
+- `describe` – Provide a short description without citing the author.
+- `release` – Focus on the gains or improvements described in the linked release notes.
+
+To trigger the tool from the UI:
+
+1. Ensure the **Functions** toggle is enabled in the **Tools** panel.
+2. Ask the assistant to summarize a link, for example:
+
+   ```
+   Summarize https://example.com in reference mode using the summarize_url tool.
+   ```
+
+   The assistant will call the tool and display the generated summary.
 
 ## Contributing
 

--- a/app/api/functions/summarize_url/route.ts
+++ b/app/api/functions/summarize_url/route.ts
@@ -1,0 +1,64 @@
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const url = searchParams.get("url");
+    const mode = searchParams.get("mode") || "describe";
+
+    if (!url) {
+      return new Response(JSON.stringify({ error: "Missing url" }), { status: 400 });
+    }
+
+    const res = await fetch(url);
+    if (!res.ok) {
+      return new Response(JSON.stringify({ error: "Failed to fetch url" }), { status: 500 });
+    }
+    const html = await res.text();
+
+    // Extract title and author if present
+    const titleMatch = html.match(/<title>(.*?)<\/title>/i);
+    const title = titleMatch ? titleMatch[1].trim() : url;
+    const authorMatch = html.match(/<meta[^>]*name=["']author["'][^>]*content=["'](.*?)["']/i);
+    const author = authorMatch ? authorMatch[1].trim() : "";
+
+    // Remove scripts/styles and tags
+    const cleaned = html
+      .replace(/<script[\s\S]*?<\/script>/gi, " ")
+      .replace(/<style[\s\S]*?<\/style>/gi, " ")
+      .replace(/<[^>]+>/g, " ");
+
+    const text = cleaned.replace(/\s+/g, " ").slice(0, 6000);
+
+    const OpenAI = (await import("openai")).default || (await import("openai"));
+    const openai = new OpenAI();
+
+    let system = "You summarize web pages.";
+    if (mode === "reference") {
+      system +=
+        " Return a short summary referencing the author if available in the format: In [" +
+        title +
+        "](" +
+        url +
+        ")" +
+        (author ? " @" + author + "" : "") +
+        " wrote:";
+    } else if (mode === "release") {
+      system += " Summarize the key improvements or gains from this release.";
+    } else {
+      system += " Provide a concise summary without referencing the author.";
+    }
+
+    const completion = await openai.chat.completions.create({
+      model: "gpt-4o",
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: text },
+      ],
+    });
+
+    const summary = completion.choices[0].message.content;
+    return new Response(JSON.stringify({ summary }), { status: 200 });
+  } catch (error) {
+    console.error("Error summarizing url:", error);
+    return new Response(JSON.stringify({ error: "Error summarizing url" }), { status: 500 });
+  }
+}

--- a/config/functions.ts
+++ b/config/functions.ts
@@ -49,8 +49,21 @@ export const fact_check = async ({ text }: { text: string }) => {
   return completion.choices[0].message.content;
 };
 
+export const summarize_url = async ({
+  url,
+  mode,
+}: {
+  url: string;
+  mode: "reference" | "describe" | "release";
+}) => {
+  const params = new URLSearchParams({ url, mode });
+  const res = await fetch(`/api/functions/summarize_url?${params.toString()}`);
+  return await res.json();
+};
+
 export const functionsMap = {
   get_weather: get_weather,
   get_joke: get_joke,
   fact_check: fact_check,
+  summarize_url: summarize_url,
 };

--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -33,4 +33,20 @@ export const toolsList = [
       },
     },
   },
+  {
+    name: "summarize_url",
+    description: "Summarize the content of a URL in different styles",
+    parameters: {
+      url: {
+        type: "string",
+        description: "The URL to summarize",
+      },
+      mode: {
+        type: "string",
+        enum: ["reference", "describe", "release"],
+        description:
+          "How to present the summary: reference the author, describe the event, or highlight release gains",
+      },
+    },
+  },
 ];


### PR DESCRIPTION
## Summary
- implement `summarize_url` API route
- expose `summarize_url` in function map and tool list
- document the new tool in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841c2e1074c83238eb36b3b1c53fce3