### PR TITLE
Fix missing parameter requirement in summarize_url

### DIFF
--- a/app/api/turn_response/route.ts
+++ b/app/api/turn_response/route.ts
@@ -48,6 +48,15 @@ export async function POST(request: Request) {
     });
   } catch (error) {
     console.error("Error in POST handler:", error);
+    if (error instanceof OpenAI.APIError) {
+      return NextResponse.json(
+        {
+          error: error.message,
+        },
+        { status: error.status ?? 500 }
+      );
+    }
+
     return NextResponse.json(
       {
         error: error instanceof Error ? error.message : "Unknown error",

--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -52,7 +52,7 @@ export const toolsList = [
         description: "Number of paragraphs to summarize into",
       },
     },
-    required: ["url", "mode"],
+    required: ["url", "mode", "paragraphs"],
   },
   {
     name: "create_graphic",

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -59,6 +59,12 @@ export const handleTurn = async (
 
     if (!response.ok) {
       console.error(`Error: ${response.status} - ${response.statusText}`);
+      let message = `Error ${response.status}`;
+      try {
+        const errorData = await response.json();
+        message = errorData.error || message;
+      } catch {}
+      onMessage({ event: "error", data: message });
       return;
     }
 
@@ -338,6 +344,17 @@ export const processMessages = async () => {
           toolCallMessage.status = "completed";
           setChatMessages([...chatMessages]);
         }
+        break;
+      }
+
+      case "error": {
+        const message = typeof data === "string" ? data : data?.error || "Error";
+        chatMessages.push({
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: message }],
+        });
+        setChatMessages([...chatMessages]);
         break;
       }
 


### PR DESCRIPTION
## Summary
- ensure the `summarize_url` tool marks all of its parameters as required
- return OpenAI API errors directly from `/api/turn_response`
- surface server errors back to the chat UI

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841cab193688323adec4297ad228a45