### PR TITLE
Add generate-draft tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 results.md
+draft.md

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ This will produce a `results.md` file listing each URL followed by its summary.
 
 All generated images are stored in `public/images.json`. You can compile all
 summaries and uploaded image links into `draft.md` using the `create_draft` tool
-or by running:
+or by running `npm run generate-draft`. Alternatively, you can call the API
+directly with:
 
 ```bash
 curl -X POST http://localhost:3000/api/functions/create_draft

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "generate-results": "node scripts/generate-results.js"
+    "generate-results": "node scripts/generate-results.js",
+    "generate-draft": "node scripts/generate-draft.js"
   },
   "dependencies": {
     "@npmcli/fs": "^4.0.0",

--- a/scripts/generate-draft.js
+++ b/scripts/generate-draft.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const path = require('path');
+
+async function generate() {
+  const summariesPath = path.join(__dirname, '..', 'public', 'summaries.json');
+  const imagesPath = path.join(__dirname, '..', 'public', 'images.json');
+  const draftPath = path.join(__dirname, '..', 'draft.md');
+
+  let summaries = [];
+  try {
+    summaries = JSON.parse(fs.readFileSync(summariesPath, 'utf8'));
+  } catch {
+    summaries = [];
+  }
+
+  let images = [];
+  try {
+    images = JSON.parse(fs.readFileSync(imagesPath, 'utf8'));
+  } catch {
+    images = [];
+  }
+
+  let md = '';
+  for (const item of summaries) {
+    md += `[Original link](${item.url})\n${item.summary}\n\n`;
+  }
+
+  const imgurClientId = process.env.IMGUR_CLIENT_ID;
+  const uploaded = [];
+  if (imgurClientId) {
+    for (const url of images) {
+      try {
+        const res = await fetch(url);
+        const buffer = await res.arrayBuffer();
+        const base64 = Buffer.from(buffer).toString('base64');
+        const body = new FormData();
+        body.append('image', base64);
+        const uploadRes = await fetch('https://api.imgur.com/3/image', {
+          method: 'POST',
+          headers: { Authorization: `Client-ID ${imgurClientId}` },
+          body,
+        });
+        const data = await uploadRes.json();
+        if (data?.data?.link) {
+          uploaded.push(data.data.link);
+        }
+      } catch (err) {
+        console.error('Error uploading to imgur:', err);
+      }
+    }
+  }
+
+  if (uploaded.length === 0 && images.length > 0) {
+    uploaded.push(...images);
+  }
+
+  for (const link of uploaded) {
+    md += `![Image](${link})\n\n`;
+  }
+
+  fs.writeFileSync(draftPath, md);
+  console.log('Wrote', draftPath);
+}
+
+if (require.main === module) {
+  generate();
+}
+
+module.exports = { generate };


### PR DESCRIPTION
## Summary
- add `scripts/generate-draft.js` for compiling summaries and images
- expose new tool via `npm run generate-draft`
- document draft generation in README
- ignore generated `draft.md` file

## Testing
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_6841d5c5aa808323ac1e63bf74178443