### PR TITLE
Improve draft generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,17 @@ This will produce a `results.md` file listing each URL followed by its summary.
 ### Creating a draft
 
 All generated images are stored in `public/images.json`. You can compile all
-summaries and uploaded image links into `draft.md` using the `create_draft` tool
-or by running `npm run generate-draft`. Alternatively, you can call the API
-directly with:
+summaries and uploaded image links into `draft.md` using the `generate_draft`
+task from the chat interface or by running `npm run generate-draft` locally.
+The script writes the file and attempts to open it with your default Markdown
+viewer. Alternatively, you can call the API directly with:
 
 ```bash
 curl -X POST http://localhost:3000/api/functions/create_draft
 ```
+
+The API responds with a JSON object containing `url`, pointing to the generated
+`draft.md` file which can be opened in your browser.
 
 The markdown file lists each original URL with its summary followed by the
 uploaded images at the end.

--- a/app/api/functions/create_draft/route.ts
+++ b/app/api/functions/create_draft/route.ts
@@ -63,7 +63,7 @@ export async function POST() {
 
     await fs.writeFile(draftPath, md);
 
-    return NextResponse.json({ draft: "draft.md" });
+    return NextResponse.json({ url: "/draft.md" });
   } catch (error) {
     console.error("Error creating draft:", error);
     return NextResponse.json({ error: "Failed to create draft" }, { status: 500 });

--- a/config/functions.ts
+++ b/config/functions.ts
@@ -95,6 +95,20 @@ export const create_draft = async () => {
   return res.json();
 };
 
+export const generate_draft = async () => {
+  const res = await fetch(`/api/functions/create_draft`, {
+    method: "POST",
+  });
+  const data = await res.json();
+  if (data.url) {
+    return { url: data.url };
+  }
+  if (data.draft) {
+    return { url: `/${data.draft}` };
+  }
+  return data;
+};
+
 export const functionsMap = {
   get_weather: get_weather,
   get_joke: get_joke,
@@ -102,4 +116,5 @@ export const functionsMap = {
   summarize_url: summarize_url,
   create_graphic: create_graphic,
   create_draft: create_draft,
+  generate_draft: generate_draft,
 };

--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -69,4 +69,9 @@ export const toolsList = [
     description: "Compile all summaries and images into draft.md",
     parameters: {},
   },
+  {
+    name: "generate_draft",
+    description: "Compile all summaries and images into draft.md and return the file link",
+    parameters: {},
+  },
 ];

--- a/scripts/generate-draft.js
+++ b/scripts/generate-draft.js
@@ -1,5 +1,23 @@
 const fs = require('fs');
 const path = require('path');
+const { exec } = require('child_process');
+
+function openFile(filePath) {
+  const platform = process.platform;
+  let cmd;
+  if (platform === 'darwin') {
+    cmd = `open "${filePath}"`;
+  } else if (platform === 'win32') {
+    cmd = `start "" "${filePath}"`;
+  } else {
+    cmd = `xdg-open "${filePath}"`;
+  }
+  exec(cmd, (err) => {
+    if (err) {
+      console.error('Failed to open draft:', err.message);
+    }
+  });
+}
 
 async function generate() {
   const summariesPath = path.join(__dirname, '..', 'public', 'summaries.json');
@@ -60,6 +78,7 @@ async function generate() {
 
   fs.writeFileSync(draftPath, md);
   console.log('Wrote', draftPath);
+  openFile(draftPath);
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## Summary
- automatically open `draft.md` after generating
- explain automatic opening in README
- add `generate_draft` task to chat interface and return file link

## Testing
- `npm run lint`
- `npm run build` *(fails: OPENAI_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841db118bf08323a07e2a5e3bb8868c