### PR TITLE
Add input file upload interface

### DIFF
--- a/app/api/upload_input/route.ts
+++ b/app/api/upload_input/route.ts
@@ -1,0 +1,18 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+export async function POST(request: Request) {
+  const { content } = await request.json();
+  if (!content) {
+    return new Response("Missing content", { status: 400 });
+  }
+  try {
+    const buffer = Buffer.from(content, "base64");
+    const filePath = path.join(process.cwd(), "input.md");
+    await fs.writeFile(filePath, buffer);
+    return new Response(JSON.stringify({ success: true }), { status: 200 });
+  } catch (err) {
+    console.error("Error saving input file:", err);
+    return new Response("Error saving file", { status: 500 });
+  }
+}

--- a/components/input-file-upload.tsx
+++ b/components/input-file-upload.tsx
@@ -1,0 +1,56 @@
+"use client";
+import { useState, ChangeEvent, FormEvent } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export default function InputFileUpload() {
+  const [file, setFile] = useState<File | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) {
+      setFile(e.target.files[0]);
+    }
+  };
+
+  const arrayBufferToBase64 = (buffer: ArrayBuffer) => {
+    const bytes = new Uint8Array(buffer);
+    let binary = "";
+    for (let i = 0; i < bytes.byteLength; i++) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary);
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!file) return;
+    setUploading(true);
+    try {
+      const buffer = await file.arrayBuffer();
+      const base64Content = arrayBufferToBase64(buffer);
+      const res = await fetch("/api/upload_input", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: file.name, content: base64Content }),
+      });
+      if (!res.ok) {
+        throw new Error("Failed to upload file");
+      }
+      setFile(null);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+      <Input type="file" accept=".md" onChange={handleFileChange} />
+      <Button type="submit" disabled={!file || uploading}>
+        {uploading ? "Uploading..." : "Upload"}
+      </Button>
+    </form>
+  );
+}

--- a/components/tools-panel.tsx
+++ b/components/tools-panel.tsx
@@ -5,6 +5,7 @@ import WebSearchConfig from "./websearch-config";
 import FunctionsView from "./functions-view";
 import PanelConfig from "./panel-config";
 import useToolsStore from "@/stores/useToolsStore";
+import InputFileUpload from "./input-file-upload";
 
 export default function ContextPanel() {
   const {
@@ -42,6 +43,10 @@ export default function ContextPanel() {
         >
           <FunctionsView />
         </PanelConfig>
+        <div className="space-y-2">
+          <h1 className="text-black font-medium">Upload input.md</h1>
+          <InputFileUpload />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add an API route to save uploaded file content to `input.md`
- add `InputFileUpload` component for uploading the file
- show upload widget in the tools panel

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841de16cfd08323a43e88defdcc0b62