### PR TITLE
Add LinkedIn and Substack MD generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ yarn-error.log*
 next-env.d.ts
 results.md
 draft.md
+final-*.md

--- a/README.md
+++ b/README.md
@@ -158,6 +158,20 @@ The API responds with a JSON object containing `url`, pointing to the generated
 The markdown file lists each original URL with its summary followed by the
 uploaded images at the end.
 
+### Generating platform-specific posts
+
+Provide author handle mappings in `linkedin.json` or `substack.json` at the
+project root. Run one of the following commands to create a final markdown file
+tailored for each platform:
+
+```bash
+npm run generate-linkedin
+npm run generate-substack
+```
+
+The scripts replace any `@Author Name` mention in your summaries with the
+configured handle and append a list of authors that were not matched.
+
 ## Contributing
 
 You are welcome to open issues or submit PRs to improve this app, however, please note that we may not review all suggestions.

--- a/linkedin.json
+++ b/linkedin.json
@@ -1,0 +1,3 @@
+{
+  "John Doe": "@johndoe"
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "next lint",
     "generate-results": "node scripts/generate-results.js",
-    "generate-draft": "node scripts/generate-draft.js"
+    "generate-draft": "node scripts/generate-draft.js",
+    "generate-linkedin": "node scripts/generate-final.js linkedin",
+    "generate-substack": "node scripts/generate-final.js substack"
   },
   "dependencies": {
     "@npmcli/fs": "^4.0.0",

--- a/scripts/generate-final.js
+++ b/scripts/generate-final.js
@@ -1,0 +1,73 @@
+const fs = require('fs');
+const path = require('path');
+
+function generate(platform) {
+  const summariesPath = path.join(__dirname, '..', 'public', 'summaries.json');
+  const imagesPath = path.join(__dirname, '..', 'public', 'images.json');
+  const mapPath = path.join(__dirname, '..', `${platform}.json`);
+  const outPath = path.join(__dirname, '..', `final-${platform}.md`);
+
+  let summaries = [];
+  try {
+    summaries = JSON.parse(fs.readFileSync(summariesPath, 'utf8'));
+  } catch (err) {
+    console.error('No summaries found');
+    return;
+  }
+
+  let images = [];
+  try {
+    images = JSON.parse(fs.readFileSync(imagesPath, 'utf8'));
+  } catch {
+    images = [];
+  }
+
+  let map = {};
+  try {
+    map = JSON.parse(fs.readFileSync(mapPath, 'utf8'));
+  } catch {
+    map = {};
+  }
+
+  const missing = new Set();
+  function replaceHandles(text) {
+    return text.replace(/@([A-Za-z][A-Za-z .'-]*)/g, (m, name) => {
+      const trimmed = name.trim();
+      if (map[trimmed]) {
+        return map[trimmed];
+      }
+      missing.add(trimmed);
+      return m;
+    });
+  }
+
+  let md = '';
+  for (const item of summaries) {
+    md += `[Original link](${item.url})\n${replaceHandles(item.summary)}\n\n`;
+  }
+
+  for (const link of images) {
+    md += `![Image](${link})\n\n`;
+  }
+
+  if (missing.size > 0) {
+    md += `---\nAuthors not matched: ${Array.from(missing).join(', ')}\n`;
+  }
+
+  fs.writeFileSync(outPath, md);
+  console.log('Wrote', outPath);
+  if (missing.size > 0) {
+    console.log('Unmatched authors:', Array.from(missing).join(', '));
+  }
+}
+
+if (require.main === module) {
+  const platform = process.argv[2];
+  if (!platform) {
+    console.error('Usage: node generate-final.js <linkedin|substack>');
+    process.exit(1);
+  }
+  generate(platform);
+}
+
+module.exports = { generate };

--- a/substack.json
+++ b/substack.json
@@ -1,0 +1,3 @@
+{
+  "John Doe": "@johndoe"
+}


### PR DESCRIPTION
## Summary
- ignore generated final markdowns
- add platform mapping files
- add script to generate LinkedIn/Substack markdown
- expose npm scripts for LinkedIn/Substack
- document how to generate platform posts

## Testing
- `npm run lint`
- `node scripts/generate-final.js linkedin`

------
https://chatgpt.com/codex/tasks/task_e_6841e0e4d498832398898807e0bba15c