### PR TITLE
Add tools to generate final platform posts

### DIFF
--- a/app/api/functions/generate_final/route.ts
+++ b/app/api/functions/generate_final/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  try {
+    const { platform } = await request.json();
+    if (!platform || (platform !== "linkedin" && platform !== "substack")) {
+      return NextResponse.json({ error: "Invalid platform" }, { status: 400 });
+    }
+
+    const { promises: fs } = await import("fs");
+    const path = (await import("path")).default;
+
+    const summariesPath = path.join(process.cwd(), "public", "summaries.json");
+    const imagesPath = path.join(process.cwd(), "public", "images.json");
+    const mapPath = path.join(process.cwd(), `${platform}.json`);
+    const outPath = path.join(process.cwd(), `final-${platform}.md`);
+
+    let summaries: { url: string; summary: string }[] = [];
+    try {
+      summaries = JSON.parse(await fs.readFile(summariesPath, "utf8"));
+    } catch {
+      summaries = [];
+    }
+
+    let images: string[] = [];
+    try {
+      images = JSON.parse(await fs.readFile(imagesPath, "utf8"));
+    } catch {
+      images = [];
+    }
+
+    let map: Record<string, string> = {};
+    try {
+      map = JSON.parse(await fs.readFile(mapPath, "utf8"));
+    } catch {
+      map = {};
+    }
+
+    const missing = new Set<string>();
+    function replaceHandles(text: string) {
+      return text.replace(/@([A-Za-z][A-Za-z .'-]*)/g, (m, name) => {
+        const trimmed = name.trim();
+        if (map[trimmed]) {
+          return map[trimmed];
+        }
+        missing.add(trimmed);
+        return m;
+      });
+    }
+
+    let md = "";
+    for (const item of summaries) {
+      md += `[Original link](${item.url})\n${replaceHandles(item.summary)}\n\n`;
+    }
+
+    for (const link of images) {
+      md += `![Image](${link})\n\n`;
+    }
+
+    if (missing.size > 0) {
+      md += `---\nAuthors not matched: ${Array.from(missing).join(', ')}\n`;
+    }
+
+    await fs.writeFile(outPath, md);
+
+    return NextResponse.json({ url: `/${path.basename(outPath)}`, missing: Array.from(missing) });
+  } catch (error) {
+    console.error("Error generating final content:", error);
+    return NextResponse.json({ error: "Failed to generate final" }, { status: 500 });
+  }
+}

--- a/config/functions.ts
+++ b/config/functions.ts
@@ -95,6 +95,24 @@ export const generate_draft = async () => {
   return data;
 };
 
+export const generate_linkedin = async () => {
+  const res = await fetch(`/api/functions/generate_final`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ platform: "linkedin" }),
+  });
+  return res.json();
+};
+
+export const generate_substack = async () => {
+  const res = await fetch(`/api/functions/generate_final`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ platform: "substack" }),
+  });
+  return res.json();
+};
+
 export const functionsMap = {
   get_weather: get_weather,
   get_joke: get_joke,
@@ -103,4 +121,6 @@ export const functionsMap = {
   create_graphic: create_graphic,
   create_draft: create_draft,
   generate_draft: generate_draft,
+  generate_linkedin: generate_linkedin,
+  generate_substack: generate_substack,
 };

--- a/config/tools-list.ts
+++ b/config/tools-list.ts
@@ -54,4 +54,14 @@ export const toolsList = [
     description: "Compile all summaries and images into draft.md and return the file link",
     parameters: {},
   },
+  {
+    name: "generate_linkedin",
+    description: "Create a final markdown using linkedin.json handle mappings",
+    parameters: {},
+  },
+  {
+    name: "generate_substack",
+    description: "Create a final markdown using substack.json handle mappings",
+    parameters: {},
+  },
 ];


### PR DESCRIPTION
## Summary
- add API route for generating final posts for social platforms
- expose `generate_linkedin` and `generate_substack` functions
- register new tools for LinkedIn and Substack

## Testing
- `npm run lint`
- `npm run build` *(fails: FileSearchSetup unused etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6841eccd11748323962f4f848d0494e5